### PR TITLE
Enable Dependabot for Swift with 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "security"


### PR DESCRIPTION
## Summary

This PR adds Phase 1 Dependabot setup for this repository.

## What changed

- Added `.github/dependabot.yml`.
- Enabled Dependabot updates for the `swift` ecosystem at `directory: "/"`.
- Configured daily checks.
- Added a `cooldown` policy with `default-days: 7` for version updates.
- Set `open-pull-requests-limit: 5`.
- Added dependency/security labels for triage.

## Why

This establishes baseline dependency automation and aligns with the supply-chain hardening plan tracked in the linked issue.

Closes #7