### PR TITLE
Fix Swift 6 Sendable errors for ScreenCaptureKit

### DIFF
--- a/Sources/ZoomItMacCore/Capture/LiveCaptureSession.swift
+++ b/Sources/ZoomItMacCore/Capture/LiveCaptureSession.swift
@@ -1,6 +1,6 @@
 import CoreImage
 import CoreMedia
-import ScreenCaptureKit
+@preconcurrency import ScreenCaptureKit
 
 /// A CGImage that is safe to hand across concurrency domains. CGImage is an
 /// immutable, thread-safe Core Foundation type, but it is not formally Sendable,

--- a/Sources/ZoomItMacCore/Capture/PanoramaController.swift
+++ b/Sources/ZoomItMacCore/Capture/PanoramaController.swift
@@ -1,5 +1,5 @@
 import AppKit
-import ScreenCaptureKit
+@preconcurrency import ScreenCaptureKit
 
 /// Draws a blue capture border plus an instruction banner around the panorama
 /// region. It lives in a click-through, non-shareable window so it never

--- a/Sources/ZoomItMacCore/Capture/RecordingController.swift
+++ b/Sources/ZoomItMacCore/Capture/RecordingController.swift
@@ -1,6 +1,6 @@
 import AVFoundation
 import AppKit
-import ScreenCaptureKit
+@preconcurrency import ScreenCaptureKit
 
 /// Wraps a CMSampleBuffer so it can be handed from capture callbacks to the
 /// writer queue. CMSampleBuffer is immutable once delivered and the writer

--- a/Sources/ZoomItMacCore/Capture/ScreenCaptureService.swift
+++ b/Sources/ZoomItMacCore/Capture/ScreenCaptureService.swift
@@ -1,5 +1,5 @@
 import AppKit
-import ScreenCaptureKit
+@preconcurrency import ScreenCaptureKit
 
 struct CapturedFrame {
     var image: CGImage


### PR DESCRIPTION
Add @preconcurrency to the ScreenCaptureKit import in the four Capture files that call SCShareableContent from @MainActor/actor-isolated async contexts. The non-Sendable SCShareableContent result crossing the isolation boundary is an error under StrictConcurrency (Swift 6); @preconcurrency downgrades these Sendable diagnostics to warnings until the SDK is annotated.