### PR TITLE
Build: isolate contributor builds and add camera/mic entitlements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ Launch at login requires running ZoomIt as an app bundle so macOS attributes the
 
 ```sh
 zsh Scripts/build-app.sh
-open .build/ZoomIt.app
+open ".build/ZoomIt (Dev).app"
 ```
+
+The contributor build is named `ZoomIt (Dev).app` (bundle id `com.sysinternals.zoomitmac.dev`) so it stays distinct from an installed official `ZoomIt.app` in the Screen Recording list. See [Bundle identity](#bundle-identity-dev-vs-official) below.
 
 ## Default Hotkeys
 
@@ -95,15 +97,33 @@ Testers should run the bundled app, not `swift run`. Build a release app bundle:
 zsh Scripts/build-app.sh release
 ```
 
-This produces `.build/ZoomIt.app` with the app icon, the bundled resources, and an `Info.plist` (bundle id `com.sysinternals.zoomitmac`) declaring the microphone and camera usage descriptions. The build is for the architecture of the build machine; build on Apple Silicon for Apple Silicon testers.
+This produces `.build/ZoomIt.app` with the app icon, the bundled resources, and an `Info.plist` declaring the microphone and camera usage descriptions. The build is for the architecture of the build machine; build on Apple Silicon for Apple Silicon testers.
+
+### Bundle identity: dev vs. official
+
+`Scripts/build-app.sh` picks the bundle identity from the signing identity so a locally built copy never fights the officially distributed app over macOS privacy (TCC) grants, which are keyed by bundle id **and** code-signing requirement:
+
+- **Contributor / ad-hoc build (default):** app bundle `ZoomIt (Dev).app`, bundle id `com.sysinternals.zoomitmac.dev`, display name “ZoomIt (Dev)”, ad-hoc signed. Both the distinct file name and bundle id keep it separate from an installed official `ZoomIt.app`, so its Screen Recording grant is its own row in System Settings and the two never clobber each other.
+- **Official build:** pass a real Developer ID identity and it keeps the canonical `com.sysinternals.zoomitmac` id:
+
+  ```sh
+  ZOOMIT_SIGN_IDENTITY="Developer ID Application: Your Name (TEAMID)" \
+    zsh Scripts/build-app.sh release
+  ```
+
+Override any field explicitly with `ZOOMIT_SIGN_IDENTITY`, `ZOOMIT_BUNDLE_ID`, and `ZOOMIT_DISPLAY_NAME`. Because a real signing identity has a stable, team-based designated requirement, the official app keeps its Screen Recording permission across updates; an ad-hoc build cannot share that grant since contributors don't have the certificate.
+
+### Entitlements (camera & microphone)
+
+`build-app.sh` signs the bundle with `Scripts/ZoomIt.entitlements`, which grants `com.apple.security.device.camera` and `com.apple.security.device.audio-input`. Under the hardened runtime (used by notarized builds) these are **required** for the webcam overlay and microphone recording — without them macOS denies both even after the user approves the TCC prompt. Screen Recording is pure TCC and needs no entitlement. The entitlements are embedded even for ad-hoc builds so that when the official pipeline re-signs the bundle with ESRP (`MacAppDeveloperSign`), the existing entitlements are preserved. Verify on the first signed build with `codesign -d --entitlements :- ZoomIt.app`.
 
 ### Signing options
 
 - **Distributing widely (recommended):** sign with a Developer ID Application certificate, notarize with Apple, and staple the ticket, then zip or wrap the app in a `.dmg`:
 
   ```sh
-  codesign --deep --force --options runtime \
-    --sign "Developer ID Application: Your Name (TEAMID)" .build/ZoomIt.app
+  ZOOMIT_SIGN_IDENTITY="Developer ID Application: Your Name (TEAMID)" \
+    zsh Scripts/build-app.sh release
   ditto -c -k --keepParent .build/ZoomIt.app ZoomIt.zip
   xcrun notarytool submit ZoomIt.zip --apple-id you@example.com \
     --team-id TEAMID --password APP_SPECIFIC_PASSWORD --wait

--- a/Scripts/ZoomIt.entitlements
+++ b/Scripts/ZoomIt.entitlements
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Under the hardened runtime (required for notarization), camera and
+         microphone access are gated by these entitlements in addition to the
+         usual TCC prompt. Without them the notarized app is denied the webcam
+         overlay and microphone recording. Screen Recording is pure TCC and
+         needs no entitlement. The app is intentionally NOT sandboxed. -->
+    <key>com.apple.security.device.camera</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+</dict>
+</plist>

--- a/Scripts/build-app.sh
+++ b/Scripts/build-app.sh
@@ -3,8 +3,37 @@ set -euo pipefail
 
 ROOT_DIR="${0:A:h:h}"
 CONFIGURATION="${1:-debug}"
-APP_PATH="$ROOT_DIR/.build/ZoomIt.app"
 ICON_SOURCE="$ROOT_DIR/Sources/ZoomItMacCore/Resources/ZoomItColorIcon.png"
+ENTITLEMENTS="$ROOT_DIR/Scripts/ZoomIt.entitlements"
+
+# Signing identity controls which "flavor" of the app is produced.
+#   - Ad-hoc (the default, "-"): a contributor build that cannot reproduce the
+#     official Developer ID signature. It uses a distinct .dev bundle id so its
+#     Screen Recording (and other TCC) grant is a separate entry that never
+#     collides with the officially distributed com.sysinternals.zoomitmac app.
+#   - A real identity (e.g. "Developer ID Application: Your Name (TEAMID)"): the
+#     official build, which keeps the canonical bundle id so its TCC grant is
+#     stable across updates.
+# Override any of these via the environment:
+#   ZOOMIT_SIGN_IDENTITY, ZOOMIT_BUNDLE_ID, ZOOMIT_DISPLAY_NAME
+SIGN_IDENTITY="${ZOOMIT_SIGN_IDENTITY:--}"
+if [[ "$SIGN_IDENTITY" == "-" ]]; then
+    BUNDLE_ID="${ZOOMIT_BUNDLE_ID:-com.sysinternals.zoomitmac.dev}"
+    DISPLAY_NAME="${ZOOMIT_DISPLAY_NAME:-ZoomIt (Dev)}"
+    SIGN_DESC="ad-hoc"
+else
+    BUNDLE_ID="${ZOOMIT_BUNDLE_ID:-com.sysinternals.zoomitmac}"
+    DISPLAY_NAME="${ZOOMIT_DISPLAY_NAME:-ZoomIt}"
+    SIGN_DESC="$SIGN_IDENTITY"
+fi
+
+# Name the .app bundle after the display name so a contributor's
+# "ZoomIt (Dev).app" never collides with the official "ZoomIt.app" on disk.
+# Two identically named bundles get conflated by LaunchServices and appear as a
+# single row in System Settings > Screen Recording, making it impossible to
+# grant the dev build its own permission.
+APP_NAME="${ZOOMIT_APP_NAME:-${DISPLAY_NAME}.app}"
+APP_PATH="$ROOT_DIR/.build/$APP_NAME"
 
 cd "$ROOT_DIR"
 
@@ -39,7 +68,7 @@ if [[ -f "$ICON_SOURCE" ]] && command -v sips >/dev/null && command -v iconutil 
     iconutil -c icns "$ICONSET" -o "$APP_PATH/Contents/Resources/ZoomIt.icns"
 fi
 
-cat > "$APP_PATH/Contents/Info.plist" <<'PLIST'
+cat > "$APP_PATH/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -47,17 +76,17 @@ cat > "$APP_PATH/Contents/Info.plist" <<'PLIST'
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
     <key>CFBundleDisplayName</key>
-    <string>ZoomIt</string>
+    <string>$DISPLAY_NAME</string>
     <key>CFBundleExecutable</key>
     <string>ZoomIt</string>
     <key>CFBundleIconFile</key>
     <string>ZoomIt</string>
     <key>CFBundleIdentifier</key>
-    <string>com.sysinternals.zoomitmac</string>
+    <string>$BUNDLE_ID</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleName</key>
-    <string>ZoomIt</string>
+    <string>$DISPLAY_NAME</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
@@ -76,12 +105,31 @@ cat > "$APP_PATH/Contents/Info.plist" <<'PLIST'
 </plist>
 PLIST
 
-# Ad-hoc sign the completed bundle so macOS privacy services see the real
-# CFBundleIdentifier and sealed bundle layout. The explicit designated
-# requirement keeps local TCC grants stable across rebuilds without using a
-# signing certificate.
-codesign --force --deep --sign - \
-    --requirements '=designated => identifier "com.sysinternals.zoomitmac"' \
-    "$APP_PATH" >/dev/null
+if [[ "$SIGN_IDENTITY" == "-" ]]; then
+    # Ad-hoc sign the completed bundle so macOS privacy services see the real
+    # CFBundleIdentifier and sealed bundle layout. The explicit designated
+    # requirement keeps local TCC grants stable across rebuilds without using a
+    # signing certificate. The .dev bundle id keeps this grant separate from the
+    # officially distributed app so the two never fight over one TCC record.
+    # Entitlements are embedded even for ad-hoc builds so the ESRP re-sign in
+    # the official pipeline preserves them, and so local hardened-runtime tests
+    # can still reach the camera and microphone.
+    codesign --force --deep --sign - \
+        --entitlements "$ENTITLEMENTS" \
+        --requirements "=designated => identifier \"$BUNDLE_ID\"" \
+        "$APP_PATH" >/dev/null
+else
+    # Official build: sign with the provided Developer ID identity and enable
+    # the hardened runtime so the app can be notarized. codesign derives the
+    # designated requirement from the certificate, so the TCC grant stays
+    # stable across signed updates. The entitlements grant camera/microphone
+    # access under the hardened runtime.
+    codesign --force --options runtime --sign "$SIGN_IDENTITY" \
+        --entitlements "$ENTITLEMENTS" \
+        "$APP_PATH" >/dev/null
+fi
 
 echo "$APP_PATH"
+echo "  bundle id:    $BUNDLE_ID" >&2
+echo "  display name: $DISPLAY_NAME" >&2
+echo "  signed with:  $SIGN_DESC" >&2

--- a/Scripts/reset-first-run.sh
+++ b/Scripts/reset-first-run.sh
@@ -18,9 +18,16 @@
 
 set -euo pipefail
 
-BUNDLE_ID="com.sysinternals.zoomitmac"
+# Match the bundle id produced by Scripts/build-app.sh. Contributor (ad-hoc)
+# builds use the .dev id so their privacy grants stay separate from the
+# officially distributed com.sysinternals.zoomitmac app. Override with
+# ZOOMIT_BUNDLE_ID to reset a differently-identified build.
+BUNDLE_ID="${ZOOMIT_BUNDLE_ID:-com.sysinternals.zoomitmac.dev}"
 ROOT_DIR="${0:A:h:h}"
-APP_PATH="$ROOT_DIR/.build/ZoomIt.app"
+# build-app.sh names the bundle after the display name, so the contributor
+# build is "ZoomIt (Dev).app". Override with ZOOMIT_APP_NAME if you changed it.
+APP_NAME="${ZOOMIT_APP_NAME:-ZoomIt (Dev).app}"
+APP_PATH="$ROOT_DIR/.build/$APP_NAME"
 
 keep_settings=false
 launch=true
@@ -40,7 +47,7 @@ for arg in "$@"; do
 done
 
 echo "Quitting any running ZoomIt instance…"
-pkill -f "ZoomIt.app/Contents/MacOS/ZoomIt" 2>/dev/null || true
+pkill -f "/Contents/MacOS/ZoomIt" 2>/dev/null || true
 sleep 1
 
 echo "Resetting privacy permissions (Screen Recording, Microphone, Camera) for $BUNDLE_ID…"


### PR DESCRIPTION
Contributor builds are ad-hoc signed and cannot reproduce the official Developer ID signature, so sharing the com.sysinternals.zoomitmac bundle id caused them to fight the officially distributed app over a single macOS Screen Recording (TCC) grant. Two identically named ZoomIt.app bundles also collapsed into one row in System Settings, making it impossible to grant the local build its own permission.

build-app.sh now derives the app flavor from the signing identity:
- Default (ad-hoc): bundle id com.sysinternals.zoomitmac.dev, display name "ZoomIt (Dev)", and a distinct "ZoomIt (Dev).app" bundle so its TCC grant is a separate, non-colliding entry.
- Official: pass ZOOMIT_SIGN_IDENTITY (or ZOOMIT_BUNDLE_ID / ZOOMIT_DISPLAY_NAME) to keep the canonical com.sysinternals.zoomitmac / ZoomIt.app identity.

Also embed Scripts/ZoomIt.entitlements (camera + microphone) at sign time so the webcam overlay and mic recording work under the hardened runtime used by notarized builds; signing preserves the embedded entitlements when it re-signs. Screen Recording is pure TCC and needs no entitlement.

reset-first-run.sh targets the "ZoomIt (Dev).app" / .dev id and uses a name-agnostic pkill. README documents the dev-vs-official split, the env overrides, and the entitlements.