### PR TITLE
Build: produce Universal (arm64 + x86_64) release binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Testers should run the bundled app, not `swift run`. Build a release app bundle:
 zsh Scripts/build-app.sh release
 ```
 
-This produces `.build/ZoomIt.app` with the app icon, the bundled resources, and an `Info.plist` declaring the microphone and camera usage descriptions. The build is for the architecture of the build machine; build on Apple Silicon for Apple Silicon testers.
+This produces `.build/ZoomIt.app` with the app icon, the bundled resources, and an `Info.plist` declaring the microphone and camera usage descriptions. `release` builds are **Universal** (Apple Silicon + Intel) by default; `debug` builds are native to the build machine for speed. Override the architectures with `ZOOMIT_ARCHS` (e.g. `ZOOMIT_ARCHS=arm64`). A Universal build routes through Xcode's build system, so it requires a **full Xcode** install — with only the Command Line Tools the script warns and falls back to a native build. The build summary prints the resulting architectures.
 
 ### Bundle identity: dev vs. official
 

--- a/Scripts/build-app.sh
+++ b/Scripts/build-app.sh
@@ -37,8 +37,33 @@ APP_PATH="$ROOT_DIR/.build/$APP_NAME"
 
 cd "$ROOT_DIR"
 
-swift build -c "$CONFIGURATION"
-BIN_DIR="$(swift build -c "$CONFIGURATION" --show-bin-path)"
+# Architectures. Release builds ship a Universal binary (Apple Silicon + Intel)
+# so the download runs natively on both; debug builds stay native for speed.
+# Override with ZOOMIT_ARCHS (space-separated, e.g. "arm64"); set it to empty to
+# use the toolchain default. A modern macOS agent cross-compiles the x86_64 slice
+# from Apple Silicon, so no second build machine is needed.
+if [[ -n "${ZOOMIT_ARCHS+set}" ]]; then
+    archs=(${=ZOOMIT_ARCHS})
+elif [[ "$CONFIGURATION" == "release" ]]; then
+    archs=(arm64 x86_64)
+else
+    archs=()
+fi
+arch_flags=()
+for a in $archs; do arch_flags+=(--arch $a); done
+
+# SwiftPM's multi-arch (Universal) build routes through Xcode's xcbuild, which is
+# only present with a full Xcode install — not the standalone Command Line Tools.
+# CI agents have full Xcode; a contributor on CLT-only would otherwise hard-fail,
+# so fall back to a native build with a warning.
+if (( ${#arch_flags} > 0 )) && ! xcodebuild -version >/dev/null 2>&1; then
+    echo "warning: Universal build needs full Xcode (xcodebuild); building native only." >&2
+    archs=()
+    arch_flags=()
+fi
+
+swift build -c "$CONFIGURATION" $arch_flags
+BIN_DIR="$(swift build -c "$CONFIGURATION" $arch_flags --show-bin-path)"
 
 rm -rf "$APP_PATH"
 mkdir -p "$APP_PATH/Contents/MacOS" "$APP_PATH/Contents/Resources"
@@ -133,3 +158,4 @@ echo "$APP_PATH"
 echo "  bundle id:    $BUNDLE_ID" >&2
 echo "  display name: $DISPLAY_NAME" >&2
 echo "  signed with:  $SIGN_DESC" >&2
+echo "  architectures: $(lipo -archs "$APP_PATH/Contents/MacOS/ZoomIt" 2>/dev/null || echo unknown)" >&2


### PR DESCRIPTION
release builds now compile a Universal binary via 'swift build --arch arm64 --arch x86_64' so the download runs natively on both Apple Silicon and Intel; debug builds stay native for speed. Override with ZOOMIT_ARCHS.

Multi-arch routes through Xcode's xcbuild, which is absent with the standalone Command Line Tools, so guard it: if xcodebuild is unavailable, warn and fall back to a native build instead of hard-failing. The build summary prints the resulting architectures (lipo -archs).

README documents the behavior and the full-Xcode requirement.