### PR TITLE
Add snip clipboard-on-save and save-to-folder options

### DIFF
--- a/Sources/ZoomItMacCore/Capture/ImageExporter.swift
+++ b/Sources/ZoomItMacCore/Capture/ImageExporter.swift
@@ -19,6 +19,27 @@ enum ImageExporter {
         }
     }
 
+    /// Saves the image according to the user's snip preferences: optionally
+    /// copies it to the clipboard as well, then either writes it directly to the
+    /// configured directory or presents a Save dialog. `onWillShowSaveDialog` is
+    /// invoked only when the Save dialog is about to appear, so callers can
+    /// prepare their UI (e.g. lower an overlay window).
+    static func saveImage(
+        _ image: CGImage,
+        settings: AppSettings,
+        onWillShowSaveDialog: (() -> Void)? = nil
+    ) {
+        if settings.copySnipToClipboardOnSave {
+            copyToPasteboard(image)
+        }
+        if settings.saveSnipToDirectory {
+            writeToDirectory(image, directoryPath: settings.snipSaveDirectory)
+        } else {
+            onWillShowSaveDialog?()
+            presentSavePanel(for: image)
+        }
+    }
+
     /// Presents a Save dialog defaulting to a timestamped PNG name and writes
     /// the image as PNG.
     static func presentSavePanel(for image: CGImage) {
@@ -37,6 +58,47 @@ enum ImageExporter {
             let alert = NSAlert(error: error)
             alert.runModal()
         }
+    }
+
+    /// Writes the image as a timestamped PNG into `directoryPath` (or the user's
+    /// Documents folder when it is empty), creating the directory if needed.
+    static func writeToDirectory(_ image: CGImage, directoryPath: String) {
+        let directoryURL = resolvedSaveDirectory(directoryPath)
+        let fileManager = FileManager.default
+        do {
+            try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        } catch {
+            NSApp.activate(ignoringOtherApps: true)
+            NSAlert(error: error).runModal()
+            return
+        }
+
+        let url = directoryURL.appendingPathComponent(suggestedFilename())
+        let rep = NSBitmapImageRep(cgImage: image)
+        guard let png = rep.representation(using: .png, properties: [:]) else { return }
+        do {
+            try png.write(to: url)
+        } catch {
+            NSApp.activate(ignoringOtherApps: true)
+            NSAlert(error: error).runModal()
+        }
+    }
+
+    /// The directory used when saving directly: the configured folder, or the
+    /// user's Documents folder when unset.
+    static func resolvedSaveDirectory(_ directoryPath: String) -> URL {
+        let trimmed = directoryPath.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty {
+            return defaultSaveDirectory()
+        }
+        return URL(fileURLWithPath: (trimmed as NSString).expandingTildeInPath, isDirectory: true)
+    }
+
+    /// The default save location shown in Settings and used when no directory is
+    /// configured: the user's Documents folder.
+    static func defaultSaveDirectory() -> URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
     }
 
     /// "ZoomIt YYYY-MM-DD HHMMSS.png", matching ZoomIt's unique-name scheme.

--- a/Sources/ZoomItMacCore/Capture/PanoramaController.swift
+++ b/Sources/ZoomItMacCore/Capture/PanoramaController.swift
@@ -304,8 +304,9 @@ final class PanoramaController {
         }
 
         if save {
-            onWillShowSaveDialog?()
-            ImageExporter.presentSavePanel(for: cgImage)
+            ImageExporter.saveImage(cgImage, settings: settingsStore.load()) { [weak self] in
+                self?.onWillShowSaveDialog?()
+            }
             return "Panorama ready to save"
         } else {
             ImageExporter.copyToPasteboard(cgImage)

--- a/Sources/ZoomItMacCore/Capture/SnipController.swift
+++ b/Sources/ZoomItMacCore/Capture/SnipController.swift
@@ -187,6 +187,7 @@ final class SnipController {
     private let captureService: ScreenCaptureService
     private let displayManager: DisplayManager
     private let permissionService: PermissionService
+    private let settingsStore: SettingsStore
 
     private var window: NSWindow?
     private var capturedFrame: CapturedFrame?
@@ -197,11 +198,13 @@ final class SnipController {
     init(
         captureService: ScreenCaptureService,
         displayManager: DisplayManager,
-        permissionService: PermissionService
+        permissionService: PermissionService,
+        settingsStore: SettingsStore
     ) {
         self.captureService = captureService
         self.displayManager = displayManager
         self.permissionService = permissionService
+        self.settingsStore = settingsStore
     }
 
     /// Begins a region selection. `action` chooses what to do with the selected
@@ -297,7 +300,7 @@ final class SnipController {
 
         switch action {
         case .saveImage:
-            ImageExporter.presentSavePanel(for: cropped)
+            ImageExporter.saveImage(cropped, settings: settingsStore.load())
         case .copyImage:
             ImageExporter.copyToPasteboard(cropped)
         case .recognizeText:

--- a/Sources/ZoomItMacCore/Core/ModeCoordinator.swift
+++ b/Sources/ZoomItMacCore/Core/ModeCoordinator.swift
@@ -20,7 +20,8 @@ final class ModeCoordinator {
     private lazy var snipController = SnipController(
         captureService: captureService,
         displayManager: displayManager,
-        permissionService: permissionService
+        permissionService: permissionService,
+        settingsStore: settingsStore
     )
     private var isSnipping = false
     /// Drives screen recording (Control+5 / Control+Shift+5).

--- a/Sources/ZoomItMacCore/Overlay/ZoomCanvasView.swift
+++ b/Sources/ZoomItMacCore/Overlay/ZoomCanvasView.swift
@@ -785,8 +785,18 @@ final class ZoomCanvasView: NSView {
     }
 
     /// Presents a Save dialog above the overlay (whose `.screenSaver` level would
-    /// otherwise hide it) with the cursor visible, then restores both.
+    /// otherwise hide it) with the cursor visible, then restores both. Honors the
+    /// snip preferences: also copies to the clipboard when configured, and writes
+    /// directly to the configured directory instead of showing a dialog.
     private func presentSavePanelOverOverlay(_ image: CGImage) {
+        let settings = UserDefaultsSettingsStore().load()
+        if settings.copySnipToClipboardOnSave {
+            ImageExporter.copyToPasteboard(image)
+        }
+        if settings.saveSnipToDirectory {
+            ImageExporter.writeToDirectory(image, directoryPath: settings.snipSaveDirectory)
+            return
+        }
         let savedLevel = window?.level
         let wasCursorHidden = cursorHidden
         window?.level = NSWindow.Level(rawValue: NSWindow.Level.normal.rawValue - 1)

--- a/Sources/ZoomItMacCore/Settings/SettingsStore.swift
+++ b/Sources/ZoomItMacCore/Settings/SettingsStore.swift
@@ -92,6 +92,16 @@ struct AppSettings: Equatable {
     var webcamSize: Int
     /// Border shape: 0 rectangle, 1 rounded rectangle, 2 rounded square, 3 circle.
     var webcamShape: Int
+    /// Whether a snipped/screenshot image is also copied to the clipboard when
+    /// it is saved to a file. On by default so a saved snip is always available
+    /// to paste.
+    var copySnipToClipboardOnSave: Bool
+    /// Whether saving a snip/screenshot writes directly to `snipSaveDirectory`
+    /// with an auto-generated name instead of presenting a Save dialog.
+    var saveSnipToDirectory: Bool
+    /// Directory used when `saveSnipToDirectory` is on. Empty means the user's
+    /// Documents folder.
+    var snipSaveDirectory: String
 
     /// Initial magnification levels offered on the Zoom settings tab, matching
     /// ZoomIt's g_ZoomLevels slider values.
@@ -161,7 +171,10 @@ struct AppSettings: Equatable {
         webcamDeviceID: "",
         webcamPosition: 3,
         webcamSize: 1,
-        webcamShape: 0
+        webcamShape: 0,
+        copySnipToClipboardOnSave: true,
+        saveSnipToDirectory: false,
+        snipSaveDirectory: ""
     )
 }
 
@@ -222,6 +235,9 @@ final class UserDefaultsSettingsStore: SettingsStore {
         static let webcamPosition = "webcamPosition"
         static let webcamSize = "webcamSize"
         static let webcamShape = "webcamShape"
+        static let copySnipToClipboardOnSave = "copySnipToClipboardOnSave"
+        static let saveSnipToDirectory = "saveSnipToDirectory"
+        static let snipSaveDirectory = "snipSaveDirectory"
     }
 
     private let defaults: UserDefaults
@@ -437,6 +453,18 @@ final class UserDefaultsSettingsStore: SettingsStore {
             settings.webcamShape = defaults.integer(forKey: Key.webcamShape)
         }
 
+        if defaults.object(forKey: Key.copySnipToClipboardOnSave) != nil {
+            settings.copySnipToClipboardOnSave = defaults.bool(forKey: Key.copySnipToClipboardOnSave)
+        }
+
+        if defaults.object(forKey: Key.saveSnipToDirectory) != nil {
+            settings.saveSnipToDirectory = defaults.bool(forKey: Key.saveSnipToDirectory)
+        }
+
+        if let snipSaveDirectory = defaults.string(forKey: Key.snipSaveDirectory) {
+            settings.snipSaveDirectory = snipSaveDirectory
+        }
+
         return settings
     }
 
@@ -491,5 +519,8 @@ final class UserDefaultsSettingsStore: SettingsStore {
         defaults.set(settings.webcamPosition, forKey: Key.webcamPosition)
         defaults.set(settings.webcamSize, forKey: Key.webcamSize)
         defaults.set(settings.webcamShape, forKey: Key.webcamShape)
+        defaults.set(settings.copySnipToClipboardOnSave, forKey: Key.copySnipToClipboardOnSave)
+        defaults.set(settings.saveSnipToDirectory, forKey: Key.saveSnipToDirectory)
+        defaults.set(settings.snipSaveDirectory, forKey: Key.snipSaveDirectory)
     }
 }

--- a/Sources/ZoomItMacCore/Settings/SettingsWindowController.swift
+++ b/Sources/ZoomItMacCore/Settings/SettingsWindowController.swift
@@ -50,6 +50,10 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
     private weak var microphonePopup: NSPopUpButton?
     private weak var noiseCancellationCheckbox: NSButton?
 
+    // Snip tab controls.
+    private weak var snipSaveDirectoryField: NSTextField?
+    private weak var snipSaveDirectoryBrowseButton: NSButton?
+
     // DemoType tab controls.
     private weak var demoTypeFileField: NSTextField?
 
@@ -1052,7 +1056,70 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         self.snipOcrHotKeyButton = snipOcrHotKeyButton
         let snipOcrHotKeyRow = makeRow([makeLabel("OCR region to text:"), snipOcrHotKeyButton])
 
-        return makeColumn([help, snipHotKeyRow, snipOcrHotKeyRow])
+        let copyOnSaveCheck = NSButton(
+            checkboxWithTitle: "Also copy to clipboard when saving to a file",
+            target: self,
+            action: #selector(copySnipToClipboardOnSaveChanged(_:))
+        )
+        copyOnSaveCheck.state = settings.copySnipToClipboardOnSave ? .on : .off
+
+        let saveToDirectoryCheck = NSButton(
+            checkboxWithTitle: "Save to a folder instead of asking each time",
+            target: self,
+            action: #selector(saveSnipToDirectoryChanged(_:))
+        )
+        saveToDirectoryCheck.state = settings.saveSnipToDirectory ? .on : .off
+
+        let directoryField = NSTextField(labelWithString: snipSaveDirectoryDisplayPath())
+        directoryField.translatesAutoresizingMaskIntoConstraints = false
+        directoryField.lineBreakMode = .byTruncatingMiddle
+        directoryField.widthAnchor.constraint(equalToConstant: 380).isActive = true
+        snipSaveDirectoryField = directoryField
+        let directoryBrowse = NSButton(title: "Browse…", target: self, action: #selector(chooseSnipSaveDirectory(_:)))
+        directoryBrowse.bezelStyle = .rounded
+        snipSaveDirectoryBrowseButton = directoryBrowse
+        let directoryRow = makeIndentedColumn([makeRow([makeLabel("Folder:"), directoryField, directoryBrowse])])
+
+        updateSnipSaveDirectoryControlsEnabled()
+
+        return makeColumn([help, snipHotKeyRow, snipOcrHotKeyRow, copyOnSaveCheck, saveToDirectoryCheck, directoryRow])
+    }
+
+    private func snipSaveDirectoryDisplayPath() -> String {
+        if settings.snipSaveDirectory.trimmingCharacters(in: .whitespaces).isEmpty {
+            return ImageExporter.defaultSaveDirectory().path
+        }
+        return settings.snipSaveDirectory
+    }
+
+    private func updateSnipSaveDirectoryControlsEnabled() {
+        snipSaveDirectoryField?.isEnabled = settings.saveSnipToDirectory
+        snipSaveDirectoryBrowseButton?.isEnabled = settings.saveSnipToDirectory
+    }
+
+    @objc private func copySnipToClipboardOnSaveChanged(_ sender: NSButton) {
+        settings.copySnipToClipboardOnSave = (sender.state == .on)
+        persist()
+    }
+
+    @objc private func saveSnipToDirectoryChanged(_ sender: NSButton) {
+        settings.saveSnipToDirectory = (sender.state == .on)
+        updateSnipSaveDirectoryControlsEnabled()
+        persist()
+    }
+
+    @objc private func chooseSnipSaveDirectory(_ sender: NSButton) {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = true
+        panel.prompt = "Choose"
+        panel.title = "ZoomIt: Choose Snip Folder"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        settings.snipSaveDirectory = url.path
+        snipSaveDirectoryField?.stringValue = url.path
+        persist()
     }
 
     // MARK: - Record tab


### PR DESCRIPTION
## Summary

Adds two new options to the **Snip** settings tab:

- **Also copy to clipboard when saving to a file** (on by default) — a snipped/screenshot image is copied to the clipboard even when it is saved to a file, so it's always available to paste.
- **Save to a folder instead of asking each time** (off by default) — screenshots are written directly to a chosen folder (defaulting to Documents) with a timestamped PNG name instead of showing the Save dialog.

## Details

- New `AppSettings` fields: `copySnipToClipboardOnSave`, `saveSnipToDirectory`, `snipSaveDirectory`, with load/save wiring in `UserDefaultsSettingsStore`.
- New central helper `ImageExporter.saveImage(_:settings:onWillShowSaveDialog:)` plus `writeToDirectory` / `resolvedSaveDirectory` / `defaultSaveDirectory`.
- All image save paths route through it: `SnipController` (now takes a settings store), panorama save in `PanoramaController`, and zoomed-viewport saves in `ZoomCanvasView`.
- Snip settings tab gains the two checkboxes and a Folder field + Browse button (enabled only when saving to a folder is on).

## Testing

- `swift build` and `swift run ZoomItMacSelfTest` pass (`ZoomItMacSelfTest: PASS`).
- Verified the app bundle build/relaunch flow.