### PR TITLE
Add bug report template to issue tracker

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,60 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "[Bug]: "
+labels:
+  - bug
+
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Briefly describe the issue.
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_behavior
+    attributes:
+      label: Current Behavior
+      description: What happens today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: What should happen instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Provide the steps necessary to reproduce the issue.
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Product Version
+      description: Version of the tool where the issue occurs.
+
+  - type: input
+    id: macos_version
+    attributes:
+      label: macOS Version
+      description: For example, macOS Sequoia 15.6.
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Include screenshots, logs, crash dumps, or any other relevant information.


### PR DESCRIPTION
Added a bug report template with fields for description, current behavior, expected behavior, steps to reproduce, product version, macOS version, and additional context.