### PR TITLE
Support Typing mode in Zoom mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ All global hotkeys are configurable in Settings. While zoomed, use `Option+Up` a
 - Left click enters drawing mode; drag to draw.
 - Hold `Shift` for a line, `Control` for a rectangle, `Control+Shift` for an arrow, or `Tab` for an ellipse.
 - Press `R/G/B/O/Y/P/W/K` for red, green, blue, orange, yellow, pink, white, or black; hold `Shift` with a color for highlighter ink.
-- Press `T` for typing mode, `Shift+T` for right-aligned typing, and `Up` / `Down` or the mouse wheel to adjust font size.
+- Press `T` for typing mode, `Shift+T` for right-aligned typing, and `Up` / `Down` or the mouse wheel to adjust font size. Typing works while zoomed (static and live zoom) as well as in draw mode, so you can type on the magnified view just like you can draw on it.
 - Use `Command+Z` to undo and `E` to erase annotations.
 
 ## Snip And OCR

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ All global hotkeys are configurable in Settings. While zoomed, use `Option+Up` a
 - Left click enters drawing mode; drag to draw.
 - Hold `Shift` for a line, `Control` for a rectangle, `Control+Shift` for an arrow, or `Tab` for an ellipse.
 - Press `R/G/B/O/Y/P/W/K` for red, green, blue, orange, yellow, pink, white, or black; hold `Shift` with a color for highlighter ink.
-- Press `T` for typing mode, `Shift+T` for right-aligned typing, and `Up` / `Down` or the mouse wheel to adjust font size. Typing works while zoomed (static and live zoom) as well as in draw mode, so you can type on the magnified view just like you can draw on it.
+- Press `T` for typing mode, `Shift+T` for right-aligned typing, and `Up` / `Down` or the mouse wheel to adjust font size.
+- Typing works while zoomed (static and live zoom) as well as in draw mode, so you can type on the magnified view just like you can draw on it.
 - Use `Command+Z` to undo and `E` to erase annotations.
 
 ## Snip And OCR

--- a/Sources/ZoomItMacCore/Core/ModeCoordinator.swift
+++ b/Sources/ZoomItMacCore/Core/ModeCoordinator.swift
@@ -141,9 +141,13 @@ final class ModeCoordinator {
         case .decreasePenWidth:
             annotationController.currentStyle.rootWidth = max(1, annotationController.currentStyle.rootWidth - 1)
         case .toggleTyping(let rightAligned):
+            // Typing is only available on top of a zoom or draw overlay; the
+            // canvas normally gates the T key, but ignore stray toggles from
+            // other modes so typing never lands in an inconsistent state.
             if mode == .typing {
                 mode = modeBeforeTyping
             } else {
+                guard mode == .staticZoom || mode == .liveZoom || mode == .drawOnly else { return }
                 modeBeforeTyping = mode
                 mode = .typing
                 annotationController.beginTypingSession(rightAligned: rightAligned)
@@ -333,9 +337,13 @@ final class ModeCoordinator {
 
     /// At the zoom-out floor (1x), decides whether the overlay should exit.
     /// Matches Windows ZoomIt: static zoom stays active at 1x, while live zoom
-    /// (and its typing sub-mode) still exits when zoomed all the way out.
-    static func exitsOnZoomOutFloor(mode: AppMode) -> Bool {
-        mode != .staticZoom
+    /// still exits when zoomed all the way out. Typing is a sub-mode of the
+    /// zoom/draw mode it was entered from, so it inherits that mode's behavior.
+    static func exitsOnZoomOutFloor(mode: AppMode, modeBeforeTyping: AppMode = .liveZoom) -> Bool {
+        if mode == .typing {
+            return modeBeforeTyping != .staticZoom
+        }
+        return mode != .staticZoom
     }
 
     private func zoomIn() {
@@ -357,8 +365,9 @@ final class ModeCoordinator {
         guard current > settings.minimumZoomFactor else {
             // Static zoom matches Windows ZoomIt: it stays active at 1x instead
             // of exiting when the user zooms all the way out. Only Esc (or right
-            // click) exits static zoom. Live zoom still exits at 1x.
-            if Self.exitsOnZoomOutFloor(mode: mode) {
+            // click) exits static zoom. Live zoom still exits at 1x. Typing
+            // inherits the behavior of the mode it was entered from.
+            if Self.exitsOnZoomOutFloor(mode: mode, modeBeforeTyping: modeBeforeTyping) {
                 animateExit()
             }
             return

--- a/Sources/ZoomItMacCore/Overlay/ZoomCanvasView.swift
+++ b/Sources/ZoomItMacCore/Overlay/ZoomCanvasView.swift
@@ -129,6 +129,18 @@ final class ZoomCanvasView: NSView {
 
     override var isFlipped: Bool { true }
 
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if Self.isSaveShortcut(keyCode: event.keyCode, modifierFlags: event.modifierFlags) {
+            saveViewport()
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+
+    static func isSaveShortcut(keyCode: UInt16, modifierFlags: NSEvent.ModifierFlags) -> Bool {
+        keyCode == 1 && modifierFlags.contains(.command)
+    }
+
     override func draw(_ dirtyRect: NSRect) {
         guard let context = NSGraphicsContext.current?.cgContext else { return }
 
@@ -415,7 +427,7 @@ final class ZoomCanvasView: NSView {
         case 6 where event.modifierFlags.contains(.command) || event.modifierFlags.contains(.control):
             // ⌘Z (macOS convention) or Ctrl+Z (matching Windows ZoomIt) undoes the last gesture.
             commandSink(.undo)
-        case 1 where event.modifierFlags.contains(.command):
+        case 1 where Self.isSaveShortcut(keyCode: event.keyCode, modifierFlags: event.modifierFlags):
             // ⌘S saves the whole zoomed viewport (matching ZoomIt's Ctrl+S).
             saveViewport()
         case 8 where event.modifierFlags.contains(.command):

--- a/Sources/ZoomItMacCore/SelfTest/SelfTestRunner.swift
+++ b/Sources/ZoomItMacCore/SelfTest/SelfTestRunner.swift
@@ -63,6 +63,7 @@ public enum SelfTestRunner {
         try testStandardIconIsRoundedSquareWithMargin()
         try testDefaultTypingFontIsSystem20pt()
         try testStaticZoomStaysAtOneX()
+        try testZoomSaveShortcut()
         try testPanoramaStitching()
         try testPanoramaTopSeamUsesSingleFramePixels()
         try testPanoramaVerticalSeamKeepsSingleFrame()
@@ -434,6 +435,21 @@ public enum SelfTestRunner {
                    "Expected typing entered from static zoom to stay active at 1x like static zoom")
         try expect(ModeCoordinator.exitsOnZoomOutFloor(mode: .typing),
                    "Expected typing to default to the live zoom behavior at the zoom-out floor")
+    }
+
+    private static func testZoomSaveShortcut() throws {
+        try expect(
+            ZoomCanvasView.isSaveShortcut(keyCode: 1, modifierFlags: [.command]),
+            "Expected Command-S to save the zoomed viewport"
+        )
+        try expect(
+            ZoomCanvasView.isSaveShortcut(keyCode: 1, modifierFlags: []) == false,
+            "Expected an unmodified S key not to save the zoomed viewport"
+        )
+        try expect(
+            ZoomCanvasView.isSaveShortcut(keyCode: 1, modifierFlags: [.control]) == false,
+            "Expected Control-S not to be treated as the macOS save shortcut"
+        )
     }
 
     /// The break timer view uses a flipped coordinate system. Drawing a

--- a/Sources/ZoomItMacCore/SelfTest/SelfTestRunner.swift
+++ b/Sources/ZoomItMacCore/SelfTest/SelfTestRunner.swift
@@ -421,13 +421,19 @@ public enum SelfTestRunner {
     private static func testStaticZoomStaysAtOneX() throws {
         // Windows ZoomIt keeps static zoom active when the user zooms all the
         // way out to 1x; only Esc/right-click exits. Live zoom still exits at
-        // the floor.
+        // the floor. Typing is a sub-mode of the zoom mode it was entered from
+        // (T works in both zoom and draw modes), so it inherits that mode's
+        // behavior at the floor.
         try expect(ModeCoordinator.exitsOnZoomOutFloor(mode: .staticZoom) == false,
                    "Expected static zoom to stay active at 1x instead of exiting")
         try expect(ModeCoordinator.exitsOnZoomOutFloor(mode: .liveZoom),
                    "Expected live zoom to exit when zoomed out to 1x")
-        try expect(ModeCoordinator.exitsOnZoomOutFloor(mode: .typing),
+        try expect(ModeCoordinator.exitsOnZoomOutFloor(mode: .typing, modeBeforeTyping: .liveZoom),
                    "Expected typing (live zoom sub-mode) to exit when zoomed out to 1x")
+        try expect(ModeCoordinator.exitsOnZoomOutFloor(mode: .typing, modeBeforeTyping: .staticZoom) == false,
+                   "Expected typing entered from static zoom to stay active at 1x like static zoom")
+        try expect(ModeCoordinator.exitsOnZoomOutFloor(mode: .typing),
+                   "Expected typing to default to the live zoom behavior at the zoom-out floor")
     }
 
     /// The break timer view uses a flipped coordinate system. Drawing a


### PR DESCRIPTION
This pull request adds Type mode to Zoom (previously it was only possible to Type when in Draw mode). The most important changes are:

**Typing Mode Behavior Improvements:**

* Typing mode (`T` key) is now available while zoomed (both static and live zoom) and in draw mode, allowing users to type on the magnified view just like they can draw. Typing mode is only activated from zoom or draw overlays to prevent inconsistent states. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R92) [[2]](diffhunk://#diff-129de864745b3a81faf4a113025db084cefc8102f6b60534fa41e5697a9e9cedR144-R150)
* The logic for exiting overlays at the zoom-out floor (1x) has been updated: typing mode now inherits the exit behavior of the mode it was entered from (static zoom or live zoom), ensuring consistent user experience. [[1]](diffhunk://#diff-129de864745b3a81faf4a113025db084cefc8102f6b60534fa41e5697a9e9cedL336-R346) [[2]](diffhunk://#diff-129de864745b3a81faf4a113025db084cefc8102f6b60534fa41e5697a9e9cedL360-R370) [[3]](diffhunk://#diff-f9aaad429e134742c099e7fe528f0c41c8345b679f8b848297b4a5b097dc22bcL424-R452)